### PR TITLE
(WIP) Install Bedrock on Linux

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,7 +12,12 @@ configure_bedrock () {
 
   if [ -f "$HOME/.bedrockrc" ]
   then
-    sed -i '' "/export BEDROCK_DIR/ s#=.*#=$CWD#" $HOME/.bedrockrc
+    if [ "$(uname -s)" == "Darwin" ]
+    then
+      sed -i '' "/export BEDROCK_DIR/ s#=.*#=$CWD#" $HOME/.bedrockrc
+    else
+      sed -i -e "/export BEDROCK_DIR/ s#=.*#=$CWD#" $HOME/.bedrockrc
+    fi
   else
     echo "export BEDROCK_DIR=$CWD" > $HOME/.bedrockrc
   fi


### PR DESCRIPTION
Linux Compatibility

- Modify the `sed` command so that it will work on non-OSX systems. Found a cross platform sed example [here](https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory/43453459). Resolves https://github.com/bedrock-env/bedrock/issues/4

Tested on Ubuntu running in the Windows Subsystem for Linux